### PR TITLE
Update backend setup docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,5 +13,5 @@ JWT_SECRET=your_jwt_secret_here
 API_BASE_URL=http://localhost:8000
 
 # Optional: External API configurations
-# PERPLEXITY_API_KEY=your_perplexity_api_key_here
+# PERPLEXITY_API_KEY=your_perplexity_api_key_here  # Set this if enabling advanced Perplexity routes
 # CLAUDE_API_KEY=your_claude_api_key_here

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ cd odb
 # 2. Backend Setup
 cd backend
 pip install -r requirements.txt
+pip install fastapi pydantic uvicorn  # Optional, required for advanced Perplexity endpoints
 cp ../env.example .env  # Configure your environment variables
 
 # 3. Start Backend API


### PR DESCRIPTION
## Summary
- install optional FastAPI packages in the backend setup guide
- remind about PERPLEXITY_API_KEY in env example

## Testing
- `pip install -r requirements.txt`
- `python -m pytest -q` *(fails: ModuleNotFoundError: openai)*

------
https://chatgpt.com/codex/tasks/task_b_685a4970774883229dce2bd85f864ccb