### PR TITLE
Fix tests path

### DIFF
--- a/tests/test_api_connections.py
+++ b/tests/test_api_connections.py
@@ -8,8 +8,8 @@ import sys
 from dotenv import load_dotenv
 
 # Add backend to path
-backend_dir = os.path.join(os.path.dirname(__file__), 'backend')
-sys.path.insert(0, backend_dir)
+backend_dir = os.path.join(os.path.dirname(__file__), '..', 'backend')
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'backend', 'src'))
 
 # Load environment
 load_dotenv(os.path.join(backend_dir, '.env'))

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -11,7 +11,7 @@ from datetime import datetime
 from unittest.mock import Mock, patch
 
 # Add backend to path
-sys.path.append('/Users/jacobgiebel/odb-1/backend/src')
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'backend', 'src'))
 
 print("🌐 TREND ANALYSIS API ENDPOINTS TEST")
 print("=" * 60)

--- a/tests/test_caching_system.py
+++ b/tests/test_caching_system.py
@@ -12,7 +12,7 @@ import json
 from datetime import datetime
 
 # Add backend to path
-sys.path.append('backend/src')
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'backend', 'src'))
 
 from services.cache_service import IntelligentCache, CacheConfig, CacheStrategy
 from services.perplexity_client import EnhancedPerplexityClient, PerplexityConfig, PerplexityQuery, QueryType

--- a/tests/test_compliance_core.py
+++ b/tests/test_compliance_core.py
@@ -10,7 +10,7 @@ import json
 from datetime import datetime, timedelta
 
 # Add backend to path
-sys.path.append('/Users/jacobgiebel/odb-1/backend/src')
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'backend', 'src'))
 
 print("🎯 COMPLIANCE MATRIX CORE TEST")
 print("=" * 60)

--- a/tests/test_compliance_matrix_system.py
+++ b/tests/test_compliance_matrix_system.py
@@ -11,7 +11,7 @@ from datetime import datetime, timedelta
 from unittest.mock import Mock, patch
 
 # Add backend to path
-sys.path.append('/Users/jacobgiebel/odb-1/backend/src')
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'backend', 'src'))
 
 print("🎯 COMPLIANCE MATRIX SYSTEM TEST SUITE")
 print("=" * 70)

--- a/tests/test_data_sync.py
+++ b/tests/test_data_sync.py
@@ -8,8 +8,8 @@ import sys
 from dotenv import load_dotenv
 
 # Add backend to path
-backend_dir = os.path.join(os.path.dirname(__file__), 'backend')
-sys.path.insert(0, backend_dir)
+backend_dir = os.path.join(os.path.dirname(__file__), '..', 'backend')
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'backend', 'src'))
 
 # Load environment
 load_dotenv(os.path.join(backend_dir, '.env'))

--- a/tests/test_fast_fail_system.py
+++ b/tests/test_fast_fail_system.py
@@ -11,7 +11,7 @@ from datetime import datetime, timedelta
 from unittest.mock import Mock, patch
 
 # Add backend to path
-sys.path.append('/Users/jacobgiebel/odb-1/backend/src')
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'backend', 'src'))
 
 print("🎯 FAST-FAIL FILTER SYSTEM TEST SUITE")
 print("=" * 70)

--- a/tests/test_trend_analysis.py
+++ b/tests/test_trend_analysis.py
@@ -14,7 +14,7 @@ from datetime import datetime, timedelta
 from unittest.mock import Mock, patch
 
 # Add backend to path
-sys.path.append('backend/src')
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'backend', 'src'))
 
 from services.trend_analysis_engine import (
     TimeSeriesAnalyzer, TrendAggregator, TrendAnalysisConfig,

--- a/tests/test_trend_components.py
+++ b/tests/test_trend_components.py
@@ -12,7 +12,7 @@ from datetime import datetime, timedelta
 import json
 
 # Add backend to path
-sys.path.append('/Users/jacobgiebel/odb-1/backend/src')
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'backend', 'src'))
 
 print("🎯 TREND ANALYSIS COMPONENTS TEST")
 print("=" * 60)

--- a/tests/test_win_probability_core.py
+++ b/tests/test_win_probability_core.py
@@ -12,7 +12,7 @@ import numpy as np
 from datetime import datetime, timedelta
 
 # Add backend to path
-sys.path.append('/Users/jacobgiebel/odb-1/backend/src')
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'backend', 'src'))
 
 print("🎯 WIN PROBABILITY ML CORE TEST")
 print("=" * 60)

--- a/tests/test_win_probability_system.py
+++ b/tests/test_win_probability_system.py
@@ -13,7 +13,7 @@ from datetime import datetime, timedelta
 from unittest.mock import Mock, patch
 
 # Add backend to path
-sys.path.append('/Users/jacobgiebel/odb-1/backend/src')
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'backend', 'src'))
 
 print("🎯 WIN PROBABILITY ML SYSTEM TEST SUITE")
 print("=" * 70)


### PR DESCRIPTION
## Summary
- update every test in `tests/` to use a relative path for `backend/src`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for several packages)*

------
https://chatgpt.com/codex/tasks/task_b_685a4c51f8fc8322acef65f85de8af4c